### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -25,12 +25,12 @@ xhsv2rgbw8w  	KEYWORD2
 xhsv2rgbw8t  	KEYWORD2
 xhsv2rgbw8  	KEYWORD2
 
-xrgb2rgbw8      KEYWORD2
+xrgb2rgbw8  	KEYWORD2
 
-xrgb2rgbwgamma8 KEYWORD2
-xhsv2rgbw8      KEYWORD2
-xhsv2rgbgamma8  KEYWORD2
-xhsv2rgbwgamma8 KEYWORD2
+xrgb2rgbwgamma8	KEYWORD2
+xhsv2rgbw8  	KEYWORD2
+xhsv2rgbgamma8	KEYWORD2
+xhsv2rgbwgamma8	KEYWORD2
 
 ######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords